### PR TITLE
feat/asset-plugin-hot-reload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::asset::AssetPlugin;
 
 mod states;
 mod core;
@@ -15,7 +16,10 @@ use editor::plugin::EditorPlugin;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            watch_for_changes_override: Some(true),
+            ..Default::default()
+        }))
         .init_state::<states::AppState>()
         .add_plugins(CorePlugin)
         .add_plugins(PlayerPlugin)


### PR DESCRIPTION
## Summary
- enable asset hot reload via `AssetPlugin` watch override

## Testing
- `cargo check`
- `cargo build`
- `timeout 10s env WGPU_BACKEND=gl RUST_BACKTRACE=1 cargo run` *(fails to run fully in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_685718a5f9d08330930f82b835dbe42c