### PR TITLE
feat/debug-tooling-guarded-by-cfg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ use ui::plugin::UiPlugin;
 use editor::plugin::EditorPlugin;
 
 fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins.set(AssetPlugin {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
             watch_for_changes_override: Some(true),
             ..Default::default()
         }))
@@ -24,7 +24,17 @@ fn main() {
         .add_plugins(CorePlugin)
         .add_plugins(PlayerPlugin)
         .add_plugins(EnemyPlugin)
-        .add_plugins(UiPlugin)
-        // .add_plugins(EditorPlugin)
-        .run();
+        .add_plugins(UiPlugin);
+        // .add_plugins(EditorPlugin);
+
+    #[cfg(debug_assertions)]
+    {
+        use bevy_inspector_egui::quick::WorldInspectorPlugin;
+        use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
+        app.add_plugins(WorldInspectorPlugin::new())
+           .add_plugins(FrameTimeDiagnosticsPlugin::default())
+           .add_plugins(LogDiagnosticsPlugin::default());
+    }
+
+    app.run();
 }


### PR DESCRIPTION
## Summary
- add world inspector and FPS diagnostics only for debug builds

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68571b4db6948330ab36c5fe5fddb681