### PR TITLE
chore/smoke-test-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
-# Docs
+# Pattern Forge Sandbox
+
+A Bevy 0.16 playground for experiments.
+
+## Getting Started
+
+Run the game in debug mode:
+
+```bash
+cargo run
+```
+
+When running in debug, open the **World Inspector** by pressing **F1**.
+
+For a production-ready build:
+
+```bash
+cargo run --release
+```
 
 ## Offline Rust std-lib docs
+
 (optional, ~110 MB, ignored by Git)
 
 ```powershell
 rustup component add rust-docs
 Copy-Item "$(rustup doc --std --path)" docs/std -Recurse
-``` 
+```

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,8 @@
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$Args
+)
+
+$ErrorActionPreference = "Stop"
+
+cargo run -- $Args

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+cargo run "$@"


### PR DESCRIPTION
## Summary
- add cross-platform dev scripts for running `cargo run`
- document debug and release boot steps in README
- lint README to pass markdownlint

## Testing
- `cargo clippy --no-deps`
- `npx -y markdownlint-cli README.md`

------
https://chatgpt.com/codex/tasks/task_e_68572a0ac6e483308eb76c64ce14b70c