### PR TITLE
chore/inspector-plugin-ordering-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Run the game in debug mode:
 cargo run
 ```
 
-When running in debug, open the **World Inspector** by pressing **F1**.
+The **World Inspector** is compiled only in debug builds. It relies on
+`EguiPlugin` being added before `WorldInspectorPlugin` in `main.rs`. When
+running in debug, open the inspector by pressing **F1**.
 
 For a production-ready build:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,41 @@
-use bevy::prelude::*;
 use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
 
-mod states;
 mod core;
-mod player;
-mod enemy;
-mod ui;
 mod editor;
+mod enemy;
+mod player;
+mod states;
+mod ui;
 
 use core::plugin::CorePlugin;
-use player::plugin::PlayerPlugin;
 use enemy::plugin::EnemyPlugin;
+use player::plugin::PlayerPlugin;
 use ui::plugin::UiPlugin;
-use editor::plugin::EditorPlugin;
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(AssetPlugin {
-            watch_for_changes_override: Some(true),
-            ..Default::default()
-        }))
-        .init_state::<states::AppState>()
-        .add_plugins(CorePlugin)
-        .add_plugins(PlayerPlugin)
-        .add_plugins(EnemyPlugin)
-        .add_plugins(UiPlugin);
-        // .add_plugins(EditorPlugin);
+        watch_for_changes_override: Some(true),
+        ..Default::default()
+    }))
+    .add_plugins(bevy_inspector_egui::bevy_egui::EguiPlugin {
+        enable_multipass_for_primary_context: true,
+    })
+    .init_state::<states::AppState>()
+    .add_plugins(CorePlugin)
+    .add_plugins(PlayerPlugin)
+    .add_plugins(EnemyPlugin)
+    .add_plugins(UiPlugin);
+    // .add_plugins(EditorPlugin);
 
     #[cfg(debug_assertions)]
     {
-        use bevy_inspector_egui::quick::WorldInspectorPlugin;
         use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
+        use bevy_inspector_egui::quick::WorldInspectorPlugin;
         app.add_plugins(WorldInspectorPlugin::new())
-           .add_plugins(FrameTimeDiagnosticsPlugin::default())
-           .add_plugins(LogDiagnosticsPlugin::default());
+            .add_plugins(FrameTimeDiagnosticsPlugin::default())
+            .add_plugins(LogDiagnosticsPlugin::default());
     }
 
     app.run();

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+#[test]
+fn debug_build_and_help() {
+    assert!(
+        Command::new("cargo")
+            .arg("build")
+            .status()
+            .expect("build failed")
+            .success()
+    );
+
+    assert!(
+        Command::new("cargo")
+            .args(["run", "--", "--help"])
+            .status()
+            .expect("run failed")
+            .success()
+    );
+}


### PR DESCRIPTION
## Summary
- ensure Egui plugin loads before `WorldInspectorPlugin`
- gate inspector to debug builds
- add integration smoke test for `cargo build` and `cargo run -- --help`
- document inspector plugin ordering in README

## Testing
- `cargo clippy --no-deps`
- `cargo test -- -Z unstable-options --report-time` *(fails: thread 'debug_build_and_help' panicked because of missing display)*

------
https://chatgpt.com/codex/tasks/task_e_68573c1dd008833087741ae3223c8533